### PR TITLE
Fix for negative days, misspelling, add new command

### DIFF
--- a/cogs/images.py
+++ b/cogs/images.py
@@ -268,9 +268,16 @@ class ImageCommands(commands.Cog, name="Fun Image Commands"):
         
     @commands.command()
     @commands.cooldown(rate=CD_GLOBAL_RATE, per=CD_GLOBAL_PER, type=CD_GLOBAL_TYPE)
-    async def bigmacksack(self, ctx):
+    async def bigmacsack(self, ctx):
         """ Big Mac Sack """
         await ctx.send(embed=build_image_embed(title="BigMacSack", image="https://i.imgur.com/XUdlxBe.gif"))
+
+    @commands.command()
+    @commands.cooldown(rate=CD_GLOBAL_RATE, per=CD_GLOBAL_PER, type=CD_GLOBAL_TYPE)
+    async def thatsracist(self, ctx):
+        """ Thats Racist """
+        await ctx.send(embed=build_image_embed(title="ThatsRacist", image="https://user-images.githubusercontent.com/38467524/96499696-5e421600-1213-11eb-8ebc-fa9cf02a0610.gif"))
+
 
 def setup(bot):
     bot.add_cog(ImageCommands(bot))

--- a/cogs/text.py
+++ b/cogs/text.py
@@ -281,11 +281,27 @@ class TextCommands(commands.Cog):
         if not games:
             return await edit_msg.edit(content="No games found!")
 
+        def leap_year(y):
+            if y % 400 == 0:
+                return True
+            if y % 100 == 0:
+                return False
+            if y % 4 == 0:
+                return True
+            else:
+                return False
+
         if team is None:
             for game in games:
                 if game.game_date_time > now_cst:
                     diff = game.game_date_time - now_cst
                     diff_cd = convert_seconds(diff.seconds)
+                    if diff.days < 0:
+                        if leap_year(datetime.date().year) is None:
+                            year_days = 365
+                        else:
+                            year_days = 366
+                        await send_countdown(diff.days + year_days, diff_cd[0], diff_cd[1], game.opponent, game.game_date_time, get_consensus_line(game), game.location)
                     await send_countdown(diff.days, diff_cd[0], diff_cd[1], game.opponent, game.game_date_time, get_consensus_line(game), game.location)
                     break
         else:
@@ -294,6 +310,12 @@ class TextCommands(commands.Cog):
                 if team.lower() == game.opponent.name.lower():
                     diff = game.game_date_time - now_cst
                     diff_cd = convert_seconds(diff.seconds)
+                    if diff.days < 0:
+                        if leap_year(datetime.date().year) is None:
+                            year_days = 365
+                        else:
+                            year_days = 366
+                        await send_countdown(diff.days + year_days, diff_cd[0], diff_cd[1], game.opponent, game.game_date_time, get_consensus_line(game), game.location)
                     await send_countdown(diff.days, diff_cd[0], diff_cd[1], game.opponent, game.game_date_time, get_consensus_line(game), game.location)
                     break
 


### PR DESCRIPTION
Add day check, if less than zero adds days based off leap year return.
Fix misspelling in `bigmacksack` -> `bigmacsack`
Add `thatsracist` command.